### PR TITLE
Picker.svelte: preventDefault on touchmove to prevent dragging whole page

### DIFF
--- a/src/lib/components/Alpha.svelte
+++ b/src/lib/components/Alpha.svelte
@@ -85,6 +85,7 @@
 	}
 
 	function touch(e) {
+		e.preventDefault();
 		onClick(
 			toRight
 				? e.changedTouches[0].clientX - alpha.getBoundingClientRect().left

--- a/src/lib/components/Picker.svelte
+++ b/src/lib/components/Picker.svelte
@@ -108,6 +108,7 @@
 	}
 
 	function touch(e) {
+		e.preventDefault();
 		onClick({
 			offsetX: e.changedTouches[0].clientX - picker.getBoundingClientRect().left,
 			offsetY: e.changedTouches[0].clientY - picker.getBoundingClientRect().top

--- a/src/lib/components/Slider.svelte
+++ b/src/lib/components/Slider.svelte
@@ -76,6 +76,7 @@
 	}
 
 	function touch(e) {
+		e.preventDefault();
 		onClick(
 			toRight
 				? e.changedTouches[0].clientX - slider.getBoundingClientRect().left


### PR DESCRIPTION
I noticed that interacting with the color picker on a touch-enabled device causes the user to drag the entire page. This PR should fix that.