### PR TITLE
Fix: clamp SV values to [0, 1] range

### DIFF
--- a/src/lib/components/Picker.svelte
+++ b/src/lib/components/Picker.svelte
@@ -90,7 +90,7 @@
 		if ($keyPressedCustom.ArrowVH) {
 			if (!focusMovementIntervalId) {
 				focusMovementCounter = 0;
-				focusMovementIntervalId = setInterval(() => {
+				focusMovementIntervalId = window.setInterval(() => {
 					let focusMovementFactor = easeInOutSin(++focusMovementCounter);
 					s = Math.min(
 						1,
@@ -100,7 +100,7 @@
 						1,
 						Math.max(0, v + ($keyPressed.ArrowUp - $keyPressed.ArrowDown) * focusMovementFactor)
 					);
-				}, 10) as number;
+				}, 10);
 			}
 		} else if (focusMovementIntervalId) {
 			clearInterval(focusMovementIntervalId);

--- a/src/lib/components/Picker.svelte
+++ b/src/lib/components/Picker.svelte
@@ -3,6 +3,7 @@
 	import { keyPressed, keyPressedCustom } from '../util/store';
 	import { easeInOutSin } from '../util/transition';
 	import type { Components, Color } from '$lib/type/types';
+	import { clamp } from '$lib/util/clamp'
 
 	export let components: Components;
 
@@ -30,8 +31,8 @@
 		let width = picker.getBoundingClientRect().width;
 		let height = picker.getBoundingClientRect().height;
 
-		s = mouse.x / width;
-		v = (height - mouse.y) / height;
+		s = clamp(mouse.x / width, 0, 1);
+		v = clamp((height - mouse.y) / height, 0, 1);
 	}
 
 	function pickerMouseDown(e: MouseEvent) {

--- a/src/lib/util/clamp.ts
+++ b/src/lib/util/clamp.ts
@@ -1,0 +1,12 @@
+
+
+/**
+ * Clamps value between a minimum and a maximum.
+ * @param value Numeric value to clamp.
+ * @param min Lower bound
+ * @param max Upper bound
+ * @returns clamped value between the lower and upper bound.
+ */
+export function clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(min, value), max);
+}


### PR DESCRIPTION
While messing around more with touch input, I discovered it was possible to input values outside of the div's bounding box:

![2022-01-26_09-16-13](https://user-images.githubusercontent.com/23149353/151126862-6c2ab368-7da0-4f5f-bc35-2332e3135cc3.gif)

This PR fixes this issue by clamping the S and V values to between 0 and 1.

I also fixed a TypeScript typing complaint in a separate commit, you can decide whether you want to pull that or not 😄 