### PR TITLE
Add on:change event

### DIFF
--- a/src/lib/components/ColorPicker.svelte
+++ b/src/lib/components/ColorPicker.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { createEventDispatcher } from 'svelte';
 	import type { RgbaColor, HsvaColor, Colord } from 'colord';
 	import { colord, extend } from 'colord';
 	import a11yPlugin from 'colord/plugins/a11y';
@@ -21,6 +22,10 @@
 	extend([a11yPlugin]);
 
 	export let components: Partial<Components> = {};
+
+	const dispatch = createEventDispatcher<{
+		change: { hsv: HsvaColor; rgb: RgbaColor; hex: string };
+	}>();
 
 	/**
 	 * Customization properties
@@ -135,6 +140,8 @@
 		_hsv = Object.assign({}, hsv);
 		_rgb = Object.assign({}, rgb);
 		_hex = hex;
+
+		dispatch('change', { hsv, rgb, hex });
 	}
 
 	$: if (hsv || rgb || hex) {


### PR DESCRIPTION
This adds an on:change event that includes the `hsv`, `rgb` and `hex` properties in the event details for external components that don't want to or can't directly bind a value.

(A sample use case is when using this inside a `slot` where we can't bind to a `let` variable.)

I've only done minimal testing on this, and it seems that the event is fired multiple times for a single change, so I would appreciate some review.

Let me know about any documentation or other changes that I should include with this.