### PR TITLE
minor fixes (#18 #25 #27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # svelte-awesome-color-picker
 
+## 2.4.0
+
+### Patch Changes
+
+- Fix tabbing into the input (thanks again to [Manstie](https://github.com/manstie))
+- Fix a11y notice display
+- Fix focus style when pressing tab ([issue #25](https://github.com/Ennoriel/svelte-awesome-color-picker/issues/25))
+- Fix default color input opening on Safari on label click ([issue #18](https://github.com/Ennoriel/svelte-awesome-color-picker/issues/18)) 
+
 ## 2.3.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## 2.4.0
 
-### Patch Changes
+### Minor Changes
 
 - Fix tabbing into the input (thanks again to [Manstie](https://github.com/manstie))
 - Fix a11y notice display
 - Fix focus style when pressing tab ([issue #25](https://github.com/Ennoriel/svelte-awesome-color-picker/issues/25))
 - Fix default color input opening on Safari on label click ([issue #18](https://github.com/Ennoriel/svelte-awesome-color-picker/issues/18)) 
+- Fix color picker initialization ([issue #27](https://github.com/Ennoriel/svelte-awesome-color-picker/issues/27)) 
 
 ## 2.3.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-awesome-color-picker",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"description": "A highly customizable color picker component library",
 	"homepage": "https://ennoriel.github.io/svelte-awesome-color-picker",
 	"repository": {

--- a/src/lib/components/Alpha.svelte
+++ b/src/lib/components/Alpha.svelte
@@ -136,8 +136,8 @@
 		height: 100%;
 		background-image: linear-gradient(45deg, #eee 25%, transparent 25%, transparent 75%, #eee 75%),
 			linear-gradient(45deg, #eee 25%, transparent 25%, transparent 75%, #eee 75%);
-		background-size: 10px 10px;
-		background-position: 0 0, 5px 5px;
+		background-size: var(--pattern-size-2x, 12px) var(--pattern-size-2x, 12px);
+		background-position: 0 0, var(--pattern-size, 6px) var(--pattern-size, 6px);
 		outline: none;
 		user-select: none;
 	}

--- a/src/lib/components/ColorPicker.svelte
+++ b/src/lib/components/ColorPicker.svelte
@@ -49,7 +49,7 @@
 	 * color properties
 	 */
 	export let rgb: RgbaColor = { r: 255, g: 0, b: 0, a: 1 };
-	export let hsv: HsvaColor = { h: 0, s: 1, v: 1, a: 1 };
+	export let hsv: HsvaColor = { h: 0, s: 100, v: 100, a: 1 };
 	export let hex = '#ff0000';
 	export let color: Colord | undefined = undefined;
 	export let isDark = false;
@@ -58,7 +58,7 @@
 	 * Internal old value to trigger color conversion
 	 */
 	let _rgb: RgbaColor = { r: 255, g: 0, b: 0, a: 1 };
-	let _hsv: HsvaColor = { h: 0, s: 1, v: 1, a: 1 };
+	let _hsv: HsvaColor = { h: 0, s: 100, v: 100, a: 1 };
 	let _hex = '#ff0000';
 
 	let span: HTMLSpanElement;
@@ -156,6 +156,8 @@
 		_hex = hex;
 
 		dispatch('input', { color, hsv, rgb, hex });
+
+		console.log(color, hsv, rgb, hex);
 	}
 
 	$: if (hsv || rgb || hex) {

--- a/src/lib/components/ColorPicker.svelte
+++ b/src/lib/components/ColorPicker.svelte
@@ -161,15 +161,11 @@
 	$: if (hsv || rgb || hex) {
 		updateColor();
 	}
-
-	function keydown(e: KeyboardEvent) {
-		if (e.key === 'Tab') span.classList.add('has-been-tabbed');
-	}
 </script>
 
 <ArrowKeyHandler />
 
-<svelte:window on:mousedown={mousedown} on:keydown={keydown} on:keyup={keyup} />
+<svelte:window on:mousedown={mousedown} on:keyup={keyup} />
 
 <span bind:this={span} class="color-picker">
 	{#if isInput}

--- a/src/lib/components/Picker.svelte
+++ b/src/lib/components/Picker.svelte
@@ -40,7 +40,7 @@
 		v = clamp((height - mouse.y) / height, 0, 1) * 100;
 	}
 
-	function pickerMouseDown(e: MouseEvent) {
+	function pickerMousedown(e: MouseEvent) {
 		if (e.button === 0) {
 			isMouseDown = true;
 			onClick(e);
@@ -145,7 +145,7 @@
 		class="picker"
 		tabindex="0"
 		bind:this={picker}
-		on:mousedown|preventDefault|stopPropagation={pickerMouseDown}
+		on:mousedown|preventDefault|stopPropagation={pickerMousedown}
 		on:touchstart={touch}
 		on:touchmove|preventDefault|stopPropagation={touch}
 		on:touchend={touch}

--- a/src/lib/components/variant/A11yHorizontalWrapper.svelte
+++ b/src/lib/components/variant/A11yHorizontalWrapper.svelte
@@ -25,6 +25,7 @@
 	@media (min-width: 768px) {
 		.isOpen {
 			display: grid;
+			gap: 5px;
 			grid-template:
 				'picker . . a11y'
 				'input input input a11y';
@@ -42,10 +43,6 @@
 	div :global(.a11y-notice) {
 		grid-area: a11y;
 		margin: 0 4px 0 6px;
-	}
-
-	div :global(.slider-wrapper) {
-		margin-left: 5px;
 	}
 
 	.isPopup {

--- a/src/lib/components/variant/chrome-picker/SliderWrapper.svelte
+++ b/src/lib/components/variant/chrome-picker/SliderWrapper.svelte
@@ -21,6 +21,9 @@
 		outline-offset: 3px;
 		transition: outline 0.2s ease-in-out;
 		user-select: none;
+
+		--pattern-size: 5px;
+		--pattern-size-2x: 10px;
 	}
 
 	div.focused {

--- a/src/lib/components/variant/default/A11yNotice.svelte
+++ b/src/lib/components/variant/default/A11yNotice.svelte
@@ -40,7 +40,7 @@
 
 <style>
 	details {
-		width: 230px;
+		width: 245px;
 		margin: 8px auto;
 	}
 

--- a/src/lib/components/variant/default/Input.svelte
+++ b/src/lib/components/variant/default/Input.svelte
@@ -55,7 +55,6 @@
 		height: 32px;
 		flex-shrink: 0;
 		cursor: pointer;
-		visibility: hidden;
 	}
 
 	.alpha {

--- a/src/lib/components/variant/default/Input.svelte
+++ b/src/lib/components/variant/default/Input.svelte
@@ -6,7 +6,12 @@
 	export let isOpen: boolean;
 </script>
 
-<label bind:this={labelWrapper}>
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<label
+	bind:this={labelWrapper} 
+	on:click|preventDefault={() => { /* prevent default behavior on safari */ }} 
+	on:mousedown|preventDefault={() => { /* prevent default behavior on safari */ }}
+>
 	<div class="container">
 		<input
 			type="color"

--- a/src/lib/components/variant/default/Input.svelte
+++ b/src/lib/components/variant/default/Input.svelte
@@ -38,10 +38,6 @@
 	.container {
 		position: relative;
 		display: block;
-		width: 30px;
-		height: 30px;
-		overflow: hidden;
-		border-radius: 15px;
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -51,10 +47,12 @@
 		margin: 0;
 		padding: 0;
 		border: none;
-		width: 32px;
-		height: 32px;
+		width: 4px;
+		height: 4px;
 		flex-shrink: 0;
 		cursor: pointer;
+		border-radius: 50%;
+		margin: 0 12px;
 	}
 
 	.alpha {
@@ -67,7 +65,7 @@
 			linear-gradient(to right, black 50%, white 50%),
 			linear-gradient(to bottom, black 50%, white 50%);
 		background-blend-mode: normal, difference, normal;
-		background-size: 15px 15px;
+		background-size: 12px 12px;
 	}
 
 	.alpha,
@@ -79,8 +77,8 @@
 		user-select: none;
 	}
 
-	:global(.has-been-tabbed) label:focus-within {
+	input:focus {
 		outline: 2px solid var(--focus-color, red);
-		outline-offset: 2px;
+		outline-offset: 15px;
 	}
 </style>

--- a/src/lib/components/variant/default/SliderIndicator.svelte
+++ b/src/lib/components/variant/default/SliderIndicator.svelte
@@ -9,11 +9,11 @@
 <style>
 	div {
 		position: absolute;
-		width: 10px;
-		height: 10px;
+		width: 9.5px;
+		height: 9.5px;
 		background-color: white;
 		border-radius: 5px;
-		margin-left: 2px;
+		margin-left: 1px;
 
 		pointer-events: none;
 		z-index: 1;

--- a/src/lib/components/variant/default/SliderWrapper.svelte
+++ b/src/lib/components/variant/default/SliderWrapper.svelte
@@ -12,9 +12,9 @@
 	div {
 		display: inline-block;
 		margin-right: 5px;
-		width: var(--slider-width, 14px);
+		width: var(--slider-width, 12px);
 		height: var(--picker-height, 200px);
-		border-radius: 7px;
+		border-radius: 6px;
 		overflow: hidden;
 		user-select: none;
 

--- a/src/lib/components/variant/default/TextInput.svelte
+++ b/src/lib/components/variant/default/TextInput.svelte
@@ -184,8 +184,8 @@
 		outline: none;
 	}
 
-	:global(.has-been-tabbed) input:focus-visible,
-	:global(.has-been-tabbed) button:focus-visible {
+	input:focus-visible,
+	button:focus-visible {
 		outline: 2px solid var(--focus-color, red);
 		outline-offset: 2px;
 	}

--- a/src/lib/components/variant/default/Wrapper.svelte
+++ b/src/lib/components/variant/default/Wrapper.svelte
@@ -32,7 +32,7 @@
 	}
 	.isPopup {
 		position: absolute;
-		top: 15px;
+		top: 30px;
 		z-index: 2;
 	}
 </style>


### PR DESCRIPTION
Included in this PR:

- Fix tabbing into the input (thanks again to [Manstie](https://github.com/manstie))
- Fix a11y notice display
- Fix focus style when pressing tab ([fix #25](https://github.com/Ennoriel/svelte-awesome-color-picker/issues/25))
- Fix default color input opening on Safari on label click ([fix #18](https://github.com/Ennoriel/svelte-awesome-color-picker/issues/18)) 
- Fix color picker initialization ([fix #27](https://github.com/Ennoriel/svelte-awesome-color-picker/issues/27))

Hello @manstie , I tried to tackle the tab issue in this. I just removed it and styled the input when focusing with the keyboard instead. Do you have any opinion about it?