### PR TITLE
Fix for non popup pickers being hidden after losing focus from Tab keyup event

### DIFF
--- a/src/lib/components/ColorPicker.svelte
+++ b/src/lib/components/ColorPicker.svelte
@@ -99,7 +99,7 @@
 	}
 
 	function keyup(e: KeyboardEvent) {
-		if (e.key === 'Tab') {
+		if (e.key === 'Tab' && isPopup) {
 			isOpen = span?.contains(document.activeElement);
 		}
 	}


### PR DESCRIPTION
I am using this amazing library as a non popup picker, and I notice when user's tab over other inputs in my application, the color picker sets the `isOpen` to false, even if the type of the picker is NOT a popup. I would expect that when `isPopup` is false, the picker should not hide or show based on focus.

Here is the code block that is the culprit here:

https://github.com/Ennoriel/svelte-awesome-color-picker/blob/dace47557fa330d339263ddc70a16fa6905628e7/src/lib/components/ColorPicker.svelte#L101-L105

I believe the easy fix to this would be to check for `isPopup` and only apply the `isOpen` on tab keyup if it is a popup picker. I am happy to make changes to my solution based on your feedback.

BTW, I think this went unnoticed in your testing because in the +page.md example, your only picker that is set to `isPopup={false}` also happens to have `components={ChromeVariant}`, which does not suffer from the same bug by coincedence due to the `ChromeVariant` containing a class `:not(.isPopup)` which sets display to `inline-flex`. This masks the bug because display none is normally set, but that component override ends up setting display to a value other than none.
You can verify my PR yourself by removing the `components={ChromeVariant}` in your `+page.md` file and pressing tab until your focus leaves the picker.

Let me know if there should be any additional changes included with this PR.

Thanks :)