### PR TITLE
Fix bug occurring when limiting the amount or changing order of textInputModes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # svelte-awesome-color-picker
 
+## 3.0.5
+
+- Fix bug occurring when limiting the amount of textModeInputs or changing the order of textModeInputs
+
 ## 3.0.4
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-awesome-color-picker",
-	"version": "3.0.4",
+	"version": "3.0.5",
 	"description": "A highly customizable color picker component library",
 	"homepage": "https://svelte-awesome-color-picker.vercel.app",
 	"repository": {

--- a/src/lib/components/variant/default/TextInput.svelte
+++ b/src/lib/components/variant/default/TextInput.svelte
@@ -27,7 +27,9 @@
 
 	const HEX_COLOR_REGEX = /^#?([A-F0-9]{6}|[A-F0-9]{8})$/i;
 
-	let mode = 0;
+	let mode: 'hex' | 'rgb' | 'hsv' = textInputModes[0] || 'hex';
+
+	$: nextMode = textInputModes[(textInputModes.indexOf(mode) + 1) % textInputModes.length];
 
 	$: h = Math.round(hsv.h);
 	$: s = Math.round(hsv.s);
@@ -61,9 +63,9 @@
 
 <div class="text-input">
 	<div class="input-container">
-		{#if mode === 0}
+		{#if mode === 'hex'}
 			<input aria-label={texts.label.hex} value={hex} on:input={updateHex} style:flex={3} />
-		{:else if mode === 1}
+		{:else if mode === 'rgb'}
 			<input aria-label={texts.label.r} value={rgb.r} type="number" min="0" max="255" on:input={updateRgb('r')} />
 			<input aria-label={texts.label.g} value={rgb.g} type="number" min="0" max="255" on:input={updateRgb('g')} />
 			<input aria-label={texts.label.b} value={rgb.b} type="number" min="0" max="255" on:input={updateRgb('b')} />
@@ -80,15 +82,15 @@
 				min="0"
 				max="1"
 				step="0.01"
-				on:input={mode <= 1 ? updateRgb('a') : updateHsv('a')}
+				on:input={mode === 'hsv' ? updateHsv('a') : updateRgb('a')}
 			/>
 		{/if}
 	</div>
 
 	{#if textInputModes.length > 1}
-		<button on:click={() => (mode = (mode + 1) % 3)}>
-			<span class="disappear" aria-hidden="true">{texts.color[textInputModes[mode]]}</span>
-			<span class="appear">{texts.changeTo} {texts.color[textInputModes[(mode + 1) % 3]]}</span>
+		<button on:click={() => (mode = nextMode)}>
+			<span class="disappear" aria-hidden="true">{texts.color[mode]}</span>
+			<span class="appear">{texts.changeTo} {nextMode}</span>
 		</button>
 	{/if}
 </div>


### PR DESCRIPTION


<!-- Thanks for publishing this PR! I really appreciate it! -->

- [x] The code change has been made (leave empty if not applicable)
- [x] The code change has been documented in the [main README](https://github.com/Ennoriel/svelte-awesome-color-picker/blob/master/README.md)
  - _not necessary with this change_
- [x] code change has been documented in the [documentation site](https://github.com/Ennoriel/svelte-awesome-color-picker/blob/master/src/routes/%2Bpage.md)
  - _not necessary with this change_
- [x] run `pnpm prettier`
- [x] code change has been added in the changelog with changeset (you can leave it to me if you're unsure)


## What was fixed
- When you pass only two modes in the `textInputModes` prop (e.g. `['rbg', 'hex']`) the mode would not switch correctly
- Choosing a single mode in `textInputModes` prop would only work with `['hex']`
- Changing the order of `textInputModes` modes would lead to wrong display of input fields