### PR TITLE
Fix "change to" mode not using custom texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # svelte-awesome-color-picker
 
+## 4.0.1
+
+- Fix "change to" mode not using custom texts
+
 ## 4.0.0
 
 ### Major Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-awesome-color-picker",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"description": "A highly customizable color picker component library",
 	"homepage": "https://svelte-awesome-color-picker.vercel.app",
 	"repository": {

--- a/src/lib/components/variant/default/TextInput.svelte
+++ b/src/lib/components/variant/default/TextInput.svelte
@@ -94,7 +94,7 @@
 	{#if textInputModes.length > 1}
 		<button type="button" onclick={() => (mode = nextMode)}>
 			<span class="disappear" aria-hidden="true">{texts.color[mode]}</span>
-			<span class="appear">{texts.changeTo} {nextMode}</span>
+			<span class="appear">{texts.changeTo} {texts.color[nextMode]}</span>
 		</button>
 	{:else}
 		<div class="button-like">{texts.color[mode]}</div>


### PR DESCRIPTION
<!-- Thanks for publishing this PR! I really appreciate it! -->

Seemingly a regression from #66

- [x] The code change has been made (leave empty if not applicable)
- [x] The code change has been documented in the [main README](https://github.com/Ennoriel/svelte-awesome-color-picker/blob/master/README.md)
- [x] code change has been documented in the [documentation site](https://github.com/Ennoriel/svelte-awesome-color-picker/blob/master/src/routes/%2Bpage.md)
- [x] run `pnpm prettier`
- [x] code change has been added in the changelog with changeset (you can leave it to me if you're unsure)
