### PR TITLE
remove unnecessary text when only one possible mode is selected

### DIFF
--- a/src/lib/components/variant/default/TextInput.svelte
+++ b/src/lib/components/variant/default/TextInput.svelte
@@ -96,8 +96,6 @@
 			<span class="disappear" aria-hidden="true">{texts.color[mode]}</span>
 			<span class="appear">{texts.changeTo} {texts.color[nextMode]}</span>
 		</button>
-	{:else}
-		<div class="button-like">{texts.color[mode]}</div>
 	{/if}
 </div>
 


### PR DESCRIPTION
When only one possible input mode is selected, it seems quite unnecessary to have an unclickable button-like box there. It uses up space, confuses the user, and the information shown in it is easily viewable by looking at the input above it.

This PR simply removes the button when there is only one possible option.