### PR TITLE
Fix: `effect_update_depth_exceeded` error on clearing the inputs in rgb & hex mode.

### DIFF
--- a/.changeset/forty-eels-battle.md
+++ b/.changeset/forty-eels-battle.md
@@ -2,4 +2,4 @@
 'svelte-awesome-color-picker': minor
 ---
 
-Fix effect_update_depth_exceeded error on clearing the values in rgb or hex.
+Fix effect_update_depth_exceeded error on clearing the values in rgb or hex (fix [issue #104](https://github.com/Ennoriel/svelte-awesome-color-picker/issues/104) - thanks to [achyutagupta](https://github.com/achyutagupta))

--- a/src/routes/sections/40-Summary.md
+++ b/src/routes/sections/40-Summary.md
@@ -1,6 +1,7 @@
 ## Summary
 
 <!-- SUMMARY -->
+
 - [Install](#install)
 - [Links](#links)
 - [Summary](#summary)
@@ -39,4 +40,4 @@
 - [Migration](#migration)
   - [upgrade from v3 to v4](#upgrade-from-v3-to-v4)
   - [upgrade from v2 to v3](#upgrade-from-v2-to-v3)
-<!-- ¤SUMMARY -->
+  <!-- ¤SUMMARY -->


### PR DESCRIPTION
<!--

Thanks for publishing this PR! I really appreciate it!
Please read the contributing guide in the file contributing.md

-->
