### PR TITLE
fix: shrink alpha grid by 1px so the color overlay covers it

### DIFF
--- a/src/lib/components/variant/default/Input.svelte
+++ b/src/lib/components/variant/default/Input.svelte
@@ -100,6 +100,16 @@ _N.A._
 		user-select: none;
 	}
 
+	/* Shrink the alpha grid by 1px on each side so the .color overlay's
+	 * anti-aliased edge fully covers it. Without this, the white alpha
+	 * grid bleeds out as a thin halo around darker selected colors on
+	 * dark page backgrounds (issue #114). The override comes after the
+	 * shared `.alpha, .color` rule above so it wins on specificity tie. */
+	.alpha {
+		width: calc(var(--input-size, 25px) - 2px);
+		height: calc(var(--input-size, 25px) - 2px);
+	}
+
 	input:focus-visible ~ .color {
 		outline: 2px solid var(--focus-color, red);
 		outline-offset: 2px;


### PR DESCRIPTION
## Summary

Closes #114.

The alpha-grid mask in \`variant/default/Input.svelte\` used the same
\`var(--input-size, 25px)\` width/height as the \`.color\` overlay
sitting on top of it. The two circles share their nominal radius
but their anti-aliased edges don't agree pixel-for-pixel, so the
white alpha-grid bleeds out as a thin halo around darker selected
colors on dark page backgrounds, the screenshot in the issue is
the clearest example.

## Fix

Override \`.alpha\`'s width/height to \`calc(var(--input-size, 25px) - 2px)\`
**after** the shared \`.alpha, .color\` rule, so it wins on the
specificity tie. 1px on each side is enough for the \`.color\`
overlay's circular edge to fully sit over the alpha grid; the grid
is no longer visible as a ring around the swatch.

The existing \`clip-path: circle(50%)\` on \`.alpha\` is left in
place, it's already a belt-and-braces guard alongside
\`border-radius: 50%\` and removing it isn't needed to fix the
bleed.

## Test plan

- [x] \`pnpm test --run\`, 12 tests pass.
- [x] \`pnpm run check\` reports the same 3 \`svelte-check\` errors
      whether the fix is applied or not (missing \`\$lib\` module
      resolution in route files); they reproduce on \`master\`
      without these changes, so they're unrelated to this PR.
- [ ] Visual confirmation against a dark page background, happy to
      attach a before/after screenshot if helpful.